### PR TITLE
feat(deps): upgrade prettier to lastest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "eslint": "^4.8.0",
     "eslint-config-m6web": "1.1.0",
     "eslint-config-prettier": "2.9.0",
-    "eslint-plugin-prettier": "2.3.1",
-    "prettier": "1.9.1",
+    "eslint-plugin-prettier": "2.5.0",
+    "prettier": "1.10.2",
     "prettier-eslint-cli": "4.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,9 +428,9 @@ eslint-plugin-jsx-a11y@6.0.2:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
 
-eslint-plugin-prettier@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
+eslint-plugin-prettier@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz#39a91dd7528eaf19cd42c0ee3f2c1f684606a05f"
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
@@ -1242,9 +1242,9 @@ prettier-eslint@^8.5.0:
     typescript "^2.5.1"
     typescript-eslint-parser "^11.0.0"
 
-prettier@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.1.tgz#41638a0d47c1efbd1b7d5a742aaa5548eab86d70"
+prettier@1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 prettier@^1.7.0:
   version "1.9.2"


### PR DESCRIPTION
Prettier 1.10 supports Vue.js formatting